### PR TITLE
Fix requirements to allow supported versions of symfony and guzzle

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,13 +10,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [7.2, 7.3, 7.4, 8.0]
+        stability: [prefer-lowest, prefer-stable]
 
-    name: P${{ matrix.php }}
+
+    name: P${{ matrix.php }}-${{ matrix.stability }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.composer/cache/files
+          key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -26,7 +34,7 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-interaction --no-progress
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose --configuration phpunit.xml.dist

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,10 @@
         "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "ext-zip" : "*",
-        "symfony/console": "^2.8|^3.4|^4.2|^5.0",
-        "symfony/finder": "^4.0|^5.0",
-        "symfony/yaml": "^5.2",
-        "guzzlehttp/guzzle": "^5.0|^6.0|^7.0"
+        "symfony/console": "^3.4|^4.4|^5.2",
+        "symfony/finder": "^3.4|^4.4|^5.2",
+        "symfony/yaml": "^3.4|^4.4|^5.2",
+        "guzzlehttp/guzzle": "^6.3|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5|^8.0|^9.0"

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
         "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "ext-zip" : "*",
-        "symfony/console": "^3.4|^4.4|^5.2",
-        "symfony/finder": "^3.4|^4.4|^5.2",
-        "symfony/yaml": "^3.4|^4.4|^5.2",
+        "symfony/console": "^3.4|^4|^5",
+        "symfony/finder": "^3|^4|^5",
+        "symfony/yaml": "^3.4|^4|^5",
         "guzzlehttp/guzzle": "^6.3|^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
This fixes #1

With guzzle <6.3 there is an error in tests, so guzzle ^6.3 is required.