### PR TITLE
Add simplified API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,17 @@ To check for security vulnerabilities in your dependencies, you may run the `sec
 php security-checker security:check /path/to/composer.lock
 ```
 
+This command will return a success status code of `0` if there are no vulnerabilities and `1` if there is at least one vulnerability.
+
 API
 -----------
 
 You may also use the API directly in your own code like so:
 
 ```php
-use Enlightn\SecurityChecker\AdvisoryAnalyzer;
-use Enlightn\SecurityChecker\AdvisoryFetcher;
-use Enlightn\SecurityChecker\AdvisoryParser;
-use Enlightn\SecurityChecker\Composer;
+use Enlightn\SecurityChecker\SecurityChecker;
 
-$parser = new AdvisoryParser((new AdvisoryFetcher)->fetchAdvisories());
-
-$dependencies = (new Composer)->getDependencies('/path/to/composer.lock');
-
-$result = (new AdvisoryAnalyzer($parser->getAdvisories()))->analyzeDependencies($dependencies);
+$result = (new SecurityChecker)->check('/path/to/composer.lock');
 ```
 
 The result above is in JSON format. The key is the package name and the value is an array of vulnerabilities based on your package version. An example is as below:

--- a/src/SecurityChecker.php
+++ b/src/SecurityChecker.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Enlightn\SecurityChecker;
+
+class SecurityChecker
+{
+    /**
+     * @param string $composerLockPath
+     * @param false $excludeDev
+     * @return array
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function check(string $composerLockPath, $excludeDev = false): array
+    {
+        $parser = new AdvisoryParser((new AdvisoryFetcher)->fetchAdvisories());
+
+        $dependencies = (new Composer)->getDependencies($composerLockPath, $excludeDev);
+
+        return (new AdvisoryAnalyzer($parser->getAdvisories()))->analyzeDependencies($dependencies);
+    }
+}

--- a/src/SecurityCheckerCommand.php
+++ b/src/SecurityCheckerCommand.php
@@ -47,11 +47,7 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         try {
-            $parser = new AdvisoryParser((new AdvisoryFetcher)->fetchAdvisories());
-
-            $dependencies = (new Composer)->getDependencies($input->getArgument('lockfile'));
-
-            $result = (new AdvisoryAnalyzer($parser->getAdvisories()))->analyzeDependencies($dependencies);
+            $result = (new SecurityChecker)->check($input->getArgument('lockfile'));
         } catch (Throwable $throwable) {
             $output->writeln(json_encode([
                 'error' => $throwable->getMessage(),


### PR DESCRIPTION
This PR simplifies the Enlightn security checker API. The `Before` option still exists but we now have a more simplified `After` option as well. There are no breaking changes with this PR.

### Before
```php
use Enlightn\SecurityChecker\AdvisoryAnalyzer;
use Enlightn\SecurityChecker\AdvisoryFetcher;
use Enlightn\SecurityChecker\AdvisoryParser;
use Enlightn\SecurityChecker\Composer;

$parser = new AdvisoryParser((new AdvisoryFetcher)->fetchAdvisories());

$dependencies = (new Composer)->getDependencies('/path/to/composer.lock');

$result = (new AdvisoryAnalyzer($parser->getAdvisories()))->analyzeDependencies($dependencies);
```

### After
```php
use Enlightn\SecurityChecker\SecurityChecker;

$result = (new SecurityChecker)->check('/path/to/composer.lock');
```