### PR TITLE
Add box.json for distributing PHAR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 docs
 phpunit.xml
 vendor
+security-checker.phar

--- a/box.json
+++ b/box.json
@@ -1,0 +1,23 @@
+{
+  "output": "security-checker.phar",
+  "chmod": "0755",
+  "compactors": [
+    "KevinGH\\Box\\Compactor\\Php"
+  ],
+  "main": "security-checker",
+  "files": [
+    "LICENSE.md"
+  ],
+  "finder": [
+    {
+      "name": "*.*",
+      "exclude": ["Tests"],
+      "in": "vendor"
+    },
+    {
+      "name": ["*.*"],
+      "in": "src"
+    }
+  ],
+  "stub": true
+}


### PR DESCRIPTION
Adding the `box.json` config file for compiling the PHAR file. We will host the PHAR file on the Enlightn website to enable security scanning tools like the [Hawkeye scanner CLI](https://github.com/hawkeyesec/scanner-cli) to use the distributed PHAR file.