### PR TITLE
Fix --no-dev input option

### DIFF
--- a/src/SecurityCheckerCommand.php
+++ b/src/SecurityCheckerCommand.php
@@ -22,8 +22,8 @@ class SecurityCheckerCommand extends Command
             ->setName('security:check')
             ->setDefinition([
                 new InputArgument('lockfile', InputArgument::OPTIONAL, 'The path to the composer.lock file', 'composer.lock'),
-                new InputOption('no-dev', '', InputOption::VALUE_OPTIONAL, 'Whether to exclude dev packages from scanning', false),
-                new InputOption('format', '', InputOption::VALUE_REQUIRED, 'The output format', 'ansi'),
+                new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Whether to exclude dev packages from scanning'),
+                new InputOption('format', null, InputOption::VALUE_REQUIRED, 'The output format', 'ansi'),
             ])
             ->setDescription('Checks for vulnerabilities in your project dependencies')
             ->setHelp(

--- a/tests/SecurityCheckerCommandTest.php
+++ b/tests/SecurityCheckerCommandTest.php
@@ -57,9 +57,8 @@ class SecurityCheckerCommandTest extends TestCase
         $commandTester = new CommandTester($command);
 
         $commandTester->execute([
-        'lockfile' => $lockFile,
-        '--no-dev' => false, // Same value if omitted
-      ]);
+            'lockfile' => $lockFile,
+        ]);
 
         $this->assertEquals(1, $commandTester->getStatusCode());
         $this->assertTrue(strpos($commandTester->getDisplay(), 'RCE vulnerability in phpunit') !== false);


### PR DESCRIPTION
Just realized that the `--no-dev` option added today in https://github.com/enlightn/security-checker/pull/14 needs to be `VALUE_NONE` for it to work. This PR fixes the bug.