### PR TITLE
add allow list option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ If you would like to exclude dev dependencies from the vulnerabilities scanning,
 php security-checker security:check /path/to/composer.lock --no-dev
 ```
 
+### Allow vulnerabilities
+
+If you would like to exclude some vulnerability, you can use the option `--allow-list` passing the CVE identifier or the CVE title as value, you can pass multiple values too:
+
+```bash
+php security-checker security:check /path/to/composer.lock --allow-list CVE-2018-15133 --allow-list "untrusted X-XSRF-TOKEN value"
+```
+
+Do not forget to wrap the title with quotes
+
 ### Custom Directory for Caching Advisories Database
 
 By default, the `SecurityChecker` API and the `security:check` command use the directory returned by the `sys_get_temp_dir` PHP function for storing the cached advisories database. If you wish to modify the directory, you may use the `--temp-dir` option:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ php security-checker security:check /path/to/composer.lock --no-dev
 
 ### Allow vulnerabilities
 
-If you would like to exclude some vulnerability, you can use the option `--allow-list` passing the CVE identifier or the CVE title as value, you can pass multiple values too:
+If you would like to exclude some vulnerabilities, you may use the `--allow-list` option by passing the CVE identifier, or the CVE title. You can pass multiple values as well:
 
 ```bash
 php security-checker security:check /path/to/composer.lock --allow-list CVE-2018-15133 --allow-list "untrusted X-XSRF-TOKEN value"

--- a/src/AdvisoryParser.php
+++ b/src/AdvisoryParser.php
@@ -19,12 +19,20 @@ class AdvisoryParser
         $this->advisoriesDirectory = $advisoriesDirectory;
     }
 
-    public function getAdvisories()
+    public function getAdvisories(array $allowList = [])
     {
         $files = (new Finder)->in($this->advisoriesDirectory)->files()->name('*.yaml');
 
         foreach ($files as $fileInfo) {
             $contents = Yaml::parseFile($fileInfo->getRealPath());
+
+            if (isset($contents['cve']) && in_array($contents['cve'], $allowList, true)) {
+                continue;
+            }
+
+            if (isset($contents['title']) && in_array($contents['title'], $allowList, true)) {
+                continue;
+            }
 
             $package = str_replace('composer://', '', $contents['reference']);
 

--- a/src/SecurityChecker.php
+++ b/src/SecurityChecker.php
@@ -17,15 +17,16 @@ class SecurityChecker
     /**
      * @param string $composerLockPath
      * @param false $excludeDev
+     * @param array $allowList
      * @return array
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function check($composerLockPath, $excludeDev = false)
+    public function check($composerLockPath, $excludeDev = false, $allowList = [])
     {
         $parser = new AdvisoryParser((new AdvisoryFetcher($this->tempDir))->fetchAdvisories());
 
         $dependencies = (new Composer)->getDependencies($composerLockPath, $excludeDev);
 
-        return (new AdvisoryAnalyzer($parser->getAdvisories()))->analyzeDependencies($dependencies);
+        return (new AdvisoryAnalyzer($parser->getAdvisories($allowList)))->analyzeDependencies($dependencies);
     }
 }

--- a/src/SecurityCheckerCommand.php
+++ b/src/SecurityCheckerCommand.php
@@ -25,6 +25,7 @@ class SecurityCheckerCommand extends Command
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Whether to exclude dev packages from scanning'),
                 new InputOption('format', null, InputOption::VALUE_REQUIRED, 'The output format', 'ansi'),
                 new InputOption('temp-dir', null, InputOption::VALUE_REQUIRED, 'The temp directory to use for caching', null),
+                new InputOption('allow-list', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'List of vulnerabilities to allow, comma separated', []),
             ])
             ->setDescription('Checks for vulnerabilities in your project dependencies')
             ->setHelp(
@@ -42,6 +43,10 @@ By default, the command displays the result in ansi, but you can also
 configure it to output JSON instead by using the <info>--format</info> option:
 
 <info>php %command.full_name% /path/to/composer.lock --format=json</info>
+
+You can specify a list of vulnerabilities to allow, you can use CVE identifier or the vulnerability title:
+
+<info>php %command.full_name% /path/to/composer.lock --allow-list CVE-2018-15133 --allow-list "untrusted X-XSRF-TOKEN value"</info>
 EOF
             );
     }
@@ -60,8 +65,14 @@ EOF
 
         $tempDir = $input->getOption('temp-dir');
 
+        $allowList = $input->getOption('allow-list');
+
         try {
-            $result = (new SecurityChecker($tempDir))->check($input->getArgument('lockfile'), $excludeDev);
+            $result = (new SecurityChecker($tempDir))->check(
+                $input->getArgument('lockfile'),
+                $excludeDev,
+                $allowList
+            );
 
             $formatter->displayResult($output, $result);
         } catch (Exception $throwable) {

--- a/src/SecurityCheckerCommand.php
+++ b/src/SecurityCheckerCommand.php
@@ -25,7 +25,7 @@ class SecurityCheckerCommand extends Command
                 new InputOption('no-dev', null, InputOption::VALUE_NONE, 'Whether to exclude dev packages from scanning'),
                 new InputOption('format', null, InputOption::VALUE_REQUIRED, 'The output format', 'ansi'),
                 new InputOption('temp-dir', null, InputOption::VALUE_REQUIRED, 'The temp directory to use for caching', null),
-                new InputOption('allow-list', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'List of vulnerabilities to allow, comma separated', []),
+                new InputOption('allow-list', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'List of vulnerabilities to allow', []),
             ])
             ->setDescription('Checks for vulnerabilities in your project dependencies')
             ->setHelp(
@@ -44,7 +44,7 @@ configure it to output JSON instead by using the <info>--format</info> option:
 
 <info>php %command.full_name% /path/to/composer.lock --format=json</info>
 
-You can specify a list of vulnerabilities to allow, you can use CVE identifier or the vulnerability title:
+You can specify a list of vulnerabilities to allow by using the CVE identifier or the vulnerability title:
 
 <info>php %command.full_name% /path/to/composer.lock --allow-list CVE-2018-15133 --allow-list "untrusted X-XSRF-TOKEN value"</info>
 EOF

--- a/tests/AdvisoryParserTest.php
+++ b/tests/AdvisoryParserTest.php
@@ -12,20 +12,13 @@ class AdvisoryParserTest extends TestCase
      */
     protected $parser;
 
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->parser = new AdvisoryParser(
-            $this->getFixturesDirectory().DIRECTORY_SEPARATOR.'php_security_advisories'
-        );
-    }
-
     /**
      * @test
      */
     public function parses_advisories()
     {
+        $this->getAdvisoryParser();
+
         $advisories = $this->parser->getAdvisories();
 
         $this->assertContains([
@@ -66,6 +59,8 @@ class AdvisoryParserTest extends TestCase
      */
     public function ignores_vulnerabilities_from_allow_list_by_vce()
     {
+        $this->getAdvisoryParser();
+
         $advisories = $this->parser->getAdvisories([
             'CVE-2017-9303'
         ]);
@@ -108,6 +103,8 @@ class AdvisoryParserTest extends TestCase
      */
     public function ignores_vulnerabilities_from_allow_list_by_title()
     {
+        $this->getAdvisoryParser();
+
         $advisories = $this->parser->getAdvisories([
             'Risk of mass-assignment vulnerabilities'
         ]);
@@ -148,5 +145,12 @@ class AdvisoryParserTest extends TestCase
     protected function getFixturesDirectory()
     {
         return __DIR__.DIRECTORY_SEPARATOR.'Fixtures';
+    }
+
+    protected function getAdvisoryParser()
+    {
+        $this->parser = new AdvisoryParser(
+            $this->getFixturesDirectory() . DIRECTORY_SEPARATOR . 'php_security_advisories'
+        );
     }
 }

--- a/tests/AdvisoryParserTest.php
+++ b/tests/AdvisoryParserTest.php
@@ -7,7 +7,10 @@ use PHPUnit\Framework\TestCase;
 
 class AdvisoryParserTest extends TestCase
 {
-    protected AdvisoryParser $parser;
+    /**
+     * @var \Enlightn\SecurityChecker\AdvisoryParser
+     */
+    protected $parser;
 
     public function setUp(): void
     {

--- a/tests/AdvisoryParserTest.php
+++ b/tests/AdvisoryParserTest.php
@@ -7,16 +7,109 @@ use PHPUnit\Framework\TestCase;
 
 class AdvisoryParserTest extends TestCase
 {
+    protected AdvisoryParser $parser;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->parser = new AdvisoryParser(
+            $this->getFixturesDirectory().DIRECTORY_SEPARATOR.'php_security_advisories'
+        );
+    }
+
     /**
      * @test
      */
     public function parses_advisories()
     {
-        $parser = new AdvisoryParser($this->getFixturesDirectory().DIRECTORY_SEPARATOR.'php_security_advisories');
-
-        $advisories = $parser->getAdvisories();
+        $advisories = $this->parser->getAdvisories();
 
         $this->assertContains([
+            'title' => 'Risk of mass-assignment vulnerabilities',
+            'link' => 'https://laravel.com/docs/5.3/upgrade#upgrade-4.1.29',
+            'cve' => null,
+            'branches' => [
+                '4.0.x' => [
+                    'time' => 1400581260,
+                    'versions' => ['>=4.0.0', '<4.0.99'],
+                ],
+                '4.1.x' => [
+                    'time' => 1400581260,
+                    'versions' => ['>=4.1.0', '<4.1.29'],
+                ],
+            ],
+        ], $advisories['laravel/framework']);
+
+        $this->assertContains([
+            'title' => 'Password reset phishing vulnerability',
+            'link' => 'https://laravel.com/docs/5.4/releases#laravel-5.4.22',
+            'cve' => 'CVE-2017-9303',
+            'branches' => [
+                '5.3.x' => [
+                    'time' => null,
+                    'versions' => ['>=5.3.0', '<=5.3.31'],
+                ],
+                '5.4.x' => [
+                    'time' => 1494179366,
+                    'versions' => ['>=5.4.0', '<5.4.22'],
+                ],
+            ],
+        ], $advisories['illuminate/auth']);
+    }
+
+    /**
+     * @test
+     */
+    public function ignores_vulnerabilities_from_allow_list_by_vce()
+    {
+        $advisories = $this->parser->getAdvisories([
+            'CVE-2017-9303'
+        ]);
+
+        $this->assertContains([
+            'title' => 'Risk of mass-assignment vulnerabilities',
+            'link' => 'https://laravel.com/docs/5.3/upgrade#upgrade-4.1.29',
+            'cve' => null,
+            'branches' => [
+                '4.0.x' => [
+                    'time' => 1400581260,
+                    'versions' => ['>=4.0.0', '<4.0.99'],
+                ],
+                '4.1.x' => [
+                    'time' => 1400581260,
+                    'versions' => ['>=4.1.0', '<4.1.29'],
+                ],
+            ],
+        ], $advisories['laravel/framework']);
+
+        $this->assertNotContains([
+            'title' => 'Password reset phishing vulnerability',
+            'link' => 'https://laravel.com/docs/5.4/releases#laravel-5.4.22',
+            'cve' => 'CVE-2017-9303',
+            'branches' => [
+                '5.3.x' => [
+                    'time' => null,
+                    'versions' => ['>=5.3.0', '<=5.3.31'],
+                ],
+                '5.4.x' => [
+                    'time' => 1494179366,
+                    'versions' => ['>=5.4.0', '<5.4.22'],
+                ],
+            ],
+        ], $advisories['illuminate/auth']);
+    }
+
+    /**
+     * @test
+     */
+    public function ignores_vulnerabilities_from_allow_list_by_title()
+    {
+        $advisories = $this->parser->getAdvisories([
+            'Risk of mass-assignment vulnerabilities'
+        ]);
+
+        $this->assertNotContains([
             'title' => 'Risk of mass-assignment vulnerabilities',
             'link' => 'https://laravel.com/docs/5.3/upgrade#upgrade-4.1.29',
             'cve' => null,

--- a/tests/SecurityCheckerCommandTest.php
+++ b/tests/SecurityCheckerCommandTest.php
@@ -83,6 +83,48 @@ class SecurityCheckerCommandTest extends TestCase
         $this->assertTrue(strpos($commandTester->getDisplay(), '[OK] 0 packages have known vulnerabilities') !== false);
     }
 
+    /**
+     * @test
+     */
+    public function can_allow_vulnerabilities_by_cve()
+    {
+        $lockFile = $this->getFixturesDirectory().DIRECTORY_SEPARATOR.'vulnerable-dev.lock';
+
+        $command = new SecurityCheckerCommand;
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            'lockfile' => $lockFile,
+            '--allow-list' => [
+                'CVE-2017-9841'
+            ]
+        ]);
+
+        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertTrue(strpos($commandTester->getDisplay(), '[OK] 0 packages have known vulnerabilities') !== false);
+    }
+
+    /**
+     * @test
+     */
+    public function can_allow_vulnerabilities_by_title()
+    {
+        $lockFile = $this->getFixturesDirectory().DIRECTORY_SEPARATOR.'vulnerable-dev.lock';
+
+        $command = new SecurityCheckerCommand;
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            'lockfile' => $lockFile,
+            '--allow-list' => [
+                'RCE vulnerability in phpunit'
+            ]
+        ]);
+
+        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertTrue(strpos($commandTester->getDisplay(), '[OK] 0 packages have known vulnerabilities') !== false);
+    }
+
     protected function getFixturesDirectory()
     {
         return __DIR__.DIRECTORY_SEPARATOR.'Fixtures';


### PR DESCRIPTION
This feature allow a list of vulnerabilities to be ignored when checking.

Use:

```
php security-checker security:check /path/to/composer.lock --allow-list CVE-2018-15133 --allow-list "untrusted X-XSRF-TOKEN value"
```

Some vulnerabilities does not have the CVE code, for these we can pass the title as shown in the example

There where no breaking changes since i just added a option to the command and all tests are passing