### PR TITLE
Force extension with --use-ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ The result above is an associative array. The key is the package name and the va
 }
 ```
 
+## Chosing ZIP tool
+
+Security checker needs to extract the vulnerability database in order to check the vulnerabilities, the option `--use-ext` will instruct security checker to use a specific tool to extract the database:
+
+```bash
+php security-checker security:check /path/to/composer.lock --use-ext system-unzip
+```
+
+Use the value `system-unzip` to use the system unzip command and the value `zip-extension` to use PHP Zip Extension. By default security checker will use the zip command and if the system does not have this command the PHP Zip Extension will be user.
+
+**OBS:** Values different than `system-unzip` or `zip-extension` will be silently ignored
 ## Contribution Guide
 
 Thank you for considering contributing to the Enlightn security-checker project! The contribution guide can be found [here](https://www.laravel-enlightn.com/docs/getting-started/contribution-guide.html).

--- a/src/AdvisoryFetcher.php
+++ b/src/AdvisoryFetcher.php
@@ -34,14 +34,14 @@ class AdvisoryFetcher
     /**
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function fetchAdvisories()
+    public function fetchAdvisories($useExt = null)
     {
         $archivePath = $this->fetchAdvisoriesArchive();
 
         (new Filesystem)->deleteDirectory($extractPath = $this->getExtractDirectoryPath());
 
         $zip = new ZipExtractor;
-        $zip->extract($archivePath, $extractPath);
+        $zip->extract($archivePath, $extractPath, $useExt);
 
         return $extractPath;
     }

--- a/src/SecurityChecker.php
+++ b/src/SecurityChecker.php
@@ -21,9 +21,9 @@ class SecurityChecker
      * @return array
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function check($composerLockPath, $excludeDev = false, $allowList = [])
+    public function check($composerLockPath, $excludeDev = false, $allowList = [], $useExt = null)
     {
-        $parser = new AdvisoryParser((new AdvisoryFetcher($this->tempDir))->fetchAdvisories());
+        $parser = new AdvisoryParser((new AdvisoryFetcher($this->tempDir))->fetchAdvisories($useExt));
 
         $dependencies = (new Composer)->getDependencies($composerLockPath, $excludeDev);
 

--- a/src/SecurityCheckerCommand.php
+++ b/src/SecurityCheckerCommand.php
@@ -49,9 +49,11 @@ You can specify a list of vulnerabilities to allow by using the CVE identifier o
 
 <info>php %command.full_name% /path/to/composer.lock --allow-list CVE-2018-15133 --allow-list "untrusted X-XSRF-TOKEN value"</info>
 
-By default the Security checker will use the OS unzip command and if your System does not have this command the PHP Zip Extension will be used.
+By default the Security checker will use the unzip command and if your System does not have this command the PHP Zip Extension will be used instead.
 
-You can chose wich tool Security Checker will user for extract the vulnerability database with the option <info>--use-ext</info>
+You can use the option <info>--use-ext</info> with the value `system-unzip` to force security checker to use the system unzip command and with the value `zip-extension` to force PHP Zip Extension
+
+<info>php %command.full_name% /path/to/composer.lock --use-ext system-unzip"</info>
 EOF
             );
     }

--- a/src/SecurityCheckerCommand.php
+++ b/src/SecurityCheckerCommand.php
@@ -26,6 +26,7 @@ class SecurityCheckerCommand extends Command
                 new InputOption('format', null, InputOption::VALUE_REQUIRED, 'The output format', 'ansi'),
                 new InputOption('temp-dir', null, InputOption::VALUE_REQUIRED, 'The temp directory to use for caching', null),
                 new InputOption('allow-list', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'List of vulnerabilities to allow', []),
+                new InputOption('use-ext', null, InputOption::VALUE_REQUIRED, 'Force a specific unzip tool', null)
             ])
             ->setDescription('Checks for vulnerabilities in your project dependencies')
             ->setHelp(
@@ -47,6 +48,10 @@ configure it to output JSON instead by using the <info>--format</info> option:
 You can specify a list of vulnerabilities to allow by using the CVE identifier or the vulnerability title:
 
 <info>php %command.full_name% /path/to/composer.lock --allow-list CVE-2018-15133 --allow-list "untrusted X-XSRF-TOKEN value"</info>
+
+By default the Security checker will use the OS unzip command and if your System does not have this command the PHP Zip Extension will be used.
+
+You can chose wich tool Security Checker will user for extract the vulnerability database with the option <info>--use-ext</info>
 EOF
             );
     }
@@ -67,11 +72,14 @@ EOF
 
         $allowList = $input->getOption('allow-list');
 
+        $useExt = $input->getOption('use-ext');
+
         try {
             $result = (new SecurityChecker($tempDir))->check(
                 $input->getArgument('lockfile'),
                 $excludeDev,
-                $allowList
+                $allowList,
+                $useExt
             );
 
             $formatter->displayResult($output, $result);

--- a/src/ZipExtractor.php
+++ b/src/ZipExtractor.php
@@ -14,8 +14,20 @@ class ZipExtractor
      * @param string $archivePath
      * @param string $extractPath
      */
-    public function extract($archivePath, $extractPath)
+    public function extract($archivePath, $extractPath, $useExt = null)
     {
+        if ($useExt === "system-unzip") {
+            $this->extractWithSystemUnzip($archivePath, $extractPath);
+             
+            return;
+        }
+
+        if ($useExt === "zip-extension") {
+            $this->extractWithZipArchive($archivePath, $extractPath);
+             
+            return;
+        }
+
         if ($this->unzipCommandExists()) {
             $this->extractWithSystemUnzip($archivePath, $extractPath);
 

--- a/tests/SecurityCheckerCommandTest.php
+++ b/tests/SecurityCheckerCommandTest.php
@@ -125,6 +125,42 @@ class SecurityCheckerCommandTest extends TestCase
         $this->assertTrue(strpos($commandTester->getDisplay(), '[OK] 0 packages have known vulnerabilities') !== false);
     }
 
+    /**
+     * @test
+     */
+    public function can_chose_unzip_with_unzip_command()
+    {
+        $lockFile = $this->getFixturesDirectory().DIRECTORY_SEPARATOR.'installed.lock';
+
+        $command = new SecurityCheckerCommand;
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            'lockfile' => $lockFile,
+            '--use-ext' => 'system-unzip'
+        ]);
+
+        $this->assertEquals(1, $commandTester->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function can_chose_unzip_with_php_zip_extension()
+    {
+        $lockFile = $this->getFixturesDirectory().DIRECTORY_SEPARATOR.'installed.lock';
+
+        $command = new SecurityCheckerCommand;
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([
+            'lockfile' => $lockFile,
+            '--use-ext' => 'zip-extension'
+        ]);
+
+        $this->assertEquals(1, $commandTester->getStatusCode());
+    }
+
     protected function getFixturesDirectory()
     {
         return __DIR__.DIRECTORY_SEPARATOR.'Fixtures';

--- a/tests/ZipExtractorTest.php
+++ b/tests/ZipExtractorTest.php
@@ -50,6 +50,46 @@ class ZipExtractorTest extends TestCase
         $this->cleanExtractDirectory($this->getExtractDirectory());
     }
 
+    /**
+     * @test
+     */
+    public function can_i_chose_extracting_with_zip_commend()
+    {
+        $extractorMock = $this->getMockBuilder(ZipExtractor::class)
+            ->setMethods(['extractWithSystemUnzip'])
+            ->getMock();
+
+        $extractorMock->expects($this->once())
+            ->method('extractWithSystemUnzip')
+            ->with($this->identicalTo("arquive/path", "extract/path"));
+
+        $extractorMock->extract(
+            "arquive/path",
+            "extract/path",
+            "system-unzip"
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function can_i_chose_extracting_with_zip_extension()
+    {
+        $extractorMock = $this->getMockBuilder(ZipExtractor::class)
+            ->setMethods(['extractWithZipArchive'])
+            ->getMock();
+
+        $extractorMock->expects($this->once())
+            ->method('extractWithZipArchive')
+            ->with($this->identicalTo("arquive/path", "extract/path"));
+
+        $extractorMock->extract(
+            "arquive/path",
+            "extract/path",
+            "zip-extension"
+        );
+    }
+
     protected function cleanExtractDirectory($extractPath)
     {
         (new Filesystem)->deleteDirectory($extractPath);

--- a/tests/ZipExtractorTest.php
+++ b/tests/ZipExtractorTest.php
@@ -53,15 +53,19 @@ class ZipExtractorTest extends TestCase
     /**
      * @test
      */
-    public function can_i_chose_extracting_with_zip_commend()
+    public function can_i_chose_extracting_with_zip_command()
     {
         $extractorMock = $this->getMockBuilder(ZipExtractor::class)
-            ->setMethods(['extractWithSystemUnzip'])
+            ->onlyMethods(['extractWithSystemUnzip', 'unzipCommandExists'])
             ->getMock();
 
         $extractorMock->expects($this->once())
             ->method('extractWithSystemUnzip')
             ->with($this->identicalTo("arquive/path", "extract/path"));
+
+        //avoids false positive
+        $extractorMock->expects($this->never())
+            ->method('unzipCommandExists');
 
         $extractorMock->extract(
             "arquive/path",
@@ -76,12 +80,16 @@ class ZipExtractorTest extends TestCase
     public function can_i_chose_extracting_with_zip_extension()
     {
         $extractorMock = $this->getMockBuilder(ZipExtractor::class)
-            ->setMethods(['extractWithZipArchive'])
+            ->onlyMethods(['extractWithZipArchive', 'unzipCommandExists'])
             ->getMock();
 
         $extractorMock->expects($this->once())
             ->method('extractWithZipArchive')
             ->with($this->identicalTo("arquive/path", "extract/path"));
+
+        //avoids false positive
+        $extractorMock->expects($this->never())
+            ->method('unzipCommandExists');
 
         $extractorMock->extract(
             "arquive/path",


### PR DESCRIPTION
Add an `--use-ext` option in order to provide a way to force a specific zip tool as the follow:

```PHP
php security-checker security:check /path/to/composer.lock --use-ext system-unzip
``` 

We can use `system-unzip` force system unzip command and `zip-extension` to force PHP Zip Extension and any other option will be silently ignored.

Some considerations:

1. If we chose for `zip-extension` explicitly and the zip extension is not installed than an exception will be thrown, should it be handled?
2. If we chose for `system-unzip` explicitly and the unzip command does not exists than an error will happen, should it be handled?
3. Because the classes are very coupled with the `new` operator i was not able to test very well without very clumsy mock strategies, i just wrote a test to ensure that ti code is running fine and nothing is broken.