### PR TITLE
Use http client discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": ">=5.6",
         "ext-json": "*",
-        "php-http/discovery": "^1.14",
+        "php-http/discovery": "^1.6.1",
         "psr/http-client-implementation": "*",
         "symfony/console": "^3.4|^4|^5|^6",
         "symfony/finder": "^3|^4|^5|^6",

--- a/composer.json
+++ b/composer.json
@@ -27,15 +27,18 @@
     "require": {
         "php": ">=5.6",
         "ext-json": "*",
+        "php-http/discovery": "^1.14",
+        "psr/http-client-implementation": "*",
         "symfony/console": "^3.4|^4|^5|^6",
         "symfony/finder": "^3|^4|^5|^6",
         "symfony/process": "^3.4|^4|^5|^6",
-        "symfony/yaml": "^3.4|^4|^5|^6",
-        "guzzlehttp/guzzle": "^6.3|^7.0"
+        "symfony/yaml": "^3.4|^4|^5|^6"
     },
     "require-dev": {
-        "ext-zip" : "*",
+        "ext-zip": "*",
         "friendsofphp/php-cs-fixer": "^2.18|^3.0",
+        "php-http/mock-client": "^1.5",
+        "php-http/socket-client": "^2.1",
         "phpunit/phpunit": "^5.5|^6|^7|^8|^9"
     },
     "bin": ["security-checker"],

--- a/src/SecurityChecker.php
+++ b/src/SecurityChecker.php
@@ -19,7 +19,6 @@ class SecurityChecker
      * @param false $excludeDev
      * @param array $allowList
      * @return array
-     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function check($composerLockPath, $excludeDev = false, $allowList = [])
     {

--- a/tests/Journal/SimpleArray.php
+++ b/tests/Journal/SimpleArray.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Enlightn\SecurityChecker\Tests\Journal;
+
+use Http\Client\Common\Plugin\Journal;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class SimpleArray implements Journal
+{
+    public $successes = [];
+    public $failures = [];
+
+    public function addSuccess(RequestInterface $request, ResponseInterface $response)
+    {
+        $this->successes[] = [$request, $response];
+    }
+
+    public function addFailure(RequestInterface $request, ClientExceptionInterface $exception)
+    {
+        $this->failures[] = [$request, $exception];
+    }
+}


### PR DESCRIPTION
The security checker now has a hard dependency on `guzzlehttp/guzzle`, which unfortunately had a few security issues in the last weeks. So even when not using guzzlehttp in your application, this would generate a security warning.

By following https://docs.php-http.org/en/latest/httplug/library-developers.html we implemented ClientDiscovery so an existing PSR-18 compatible HTTP client (i.e. symfony/http-client) could be reused.